### PR TITLE
Accept step patterns that are strings

### DIFF
--- a/cucumber-tsflow/src/StepDefinitionDecorators.ts
+++ b/cucumber-tsflow/src/StepDefinitionDecorators.ts
@@ -11,7 +11,7 @@ import { Callsite } from "./Callsite";
  * @param tag An optional tag.
  * @param timeout An optional timeout.
  */
-export function given(stepPattern: RegExp, tag?: string, timeout?: number): MethodDecorator {
+export function given(stepPattern: RegExp|string, tag?: string, timeout?: number): MethodDecorator {
     let callsite = Callsite.capture();
 
     return function(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => any | Promise<any>>) {
@@ -46,7 +46,7 @@ export function given(stepPattern: RegExp, tag?: string, timeout?: number): Meth
  * @param tag An optional tag.
  * @param timeout An optional timeout.
  */
-export function when(stepPattern: RegExp, tag?: string, timeout?: number): MethodDecorator {
+export function when(stepPattern: RegExp|string, tag?: string, timeout?: number): MethodDecorator {
     let callsite = Callsite.capture();
 
     return function(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => any | Promise<any>>) {
@@ -81,7 +81,7 @@ export function when(stepPattern: RegExp, tag?: string, timeout?: number): Metho
  * @param tag An optional tag.
  * @param timeout An optional timeout.
  */
-export function then(stepPattern: RegExp, tag?: string, timeout?: number): MethodDecorator {
+export function then(stepPattern: RegExp|string, tag?: string, timeout?: number): MethodDecorator {
     let callsite = Callsite.capture();
 
     return function(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<(...args: any[]) => any | Promise<any>>) {


### PR DESCRIPTION
Cucumber.js step definitions can accept strings instead of Regex, and [parameter types](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#defineparametertypename-preferforregexpmatch-regexp-transformer-useforsnippets) depend on that.