### PR TITLE
update binding for rest params (closes #35)

### DIFF
--- a/cucumber-tsflow-specs/src/step_definitions/test.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/test.ts
@@ -1,8 +1,15 @@
 import { equal } from "assert";
 import { before, binding, given } from "cucumber-tsflow";
 
-@binding()
+class Foo {
+  public readonly actual = true;
+}
+
+// tslint:disable-next-line:max-classes-per-file
+@binding([Foo])
 export default class TestSteps {
+  constructor(private foo: Foo) {}
+
   private actual = false;
 
   @before()
@@ -11,7 +18,8 @@ export default class TestSteps {
   }
 
   @given("foo")
-  public GivenFoo(): void {
-    return equal(this.actual, true);
+  public async GivenFoo(): Promise<void> {
+    await equal(this.actual, true);
+    await equal(this.foo.actual, true);
   }
 }

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -4,7 +4,7 @@ import * as _ from "underscore";
 import { BindingRegistry, DEFAULT_TAG } from "./binding-registry";
 import { ManagedScenarioContext } from "./managed-scenario-context";
 import { StepBinding, StepBindingFlags } from "./step-binding";
-import { ContextType, StepPattern } from "./types";
+import { ContextType, StepPattern, TypeDecorator } from "./types";
 //
 
 /**
@@ -33,8 +33,8 @@ const stepPatternRegistrations = new Map<StepPattern, StepBindingFlags>();
  *
  * An instance of the decorated class will be created for each scenario.
  */
-export function binding(requiredContextTypes?: ContextType[]) {
-  return <T>(target: { new (): T }) => {
+export function binding(requiredContextTypes?: ContextType[]): TypeDecorator {
+  return <T>(target: { new (...args: any[]): T }) => {
     ensureSystemBindings();
     const bindingRegistry = BindingRegistry.instance;
     bindingRegistry.registerContextTypesForTarget(
@@ -63,7 +63,6 @@ export function binding(requiredContextTypes?: ContextType[]) {
           bindHook(stepBinding);
         }
       });
-    return target;
   };
 }
 

--- a/cucumber-tsflow/src/types.ts
+++ b/cucumber-tsflow/src/types.ts
@@ -18,3 +18,5 @@ export interface ContextType {
    */
   new (): any;
 }
+
+export type TypeDecorator = <T>(target: { new (...args: any[]): T }) => void;


### PR DESCRIPTION
After moving away from using the built-in `ClassDecorator` (which is outdated), I missed that the new type no longer accepted any number of params on the target type that the `@binding` decorator was being applied to. I've added a new type that uses rest parameters to fix this issue.