### PR TITLE
[WIP] beforeAll/afterAll hooks

### DIFF
--- a/cucumber-tsflow-specs/features/test.feature
+++ b/cucumber-tsflow-specs/features/test.feature
@@ -3,4 +3,7 @@ Feature: Test Feature
 @foo
 Scenario: Test Scenario
     Given foo
-    
+
+@bar
+Scenario: Second Test Scenario
+    When bar

--- a/cucumber-tsflow-specs/features/test.feature
+++ b/cucumber-tsflow-specs/features/test.feature
@@ -7,3 +7,7 @@ Scenario: Test Scenario
 @bar
 Scenario: Second Test Scenario
     When bar
+
+@baz 
+Scenario: Test hooks here
+    Then baz

--- a/cucumber-tsflow-specs/src/step_definitions/Hook.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/Hook.ts
@@ -1,0 +1,12 @@
+import {AfterAll, BeforeAll} from 'cucumber';
+
+// Synchronous
+BeforeAll(function () {
+  // perform some shared setup
+  console.log("Before all");
+});
+
+// Asynchronous Promise
+AfterAll(function () {
+  console.log("After all");
+});

--- a/cucumber-tsflow-specs/src/step_definitions/test.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/test.ts
@@ -1,9 +1,11 @@
 import { equal } from "assert";
-import { after, afterAll, before, beforeAll, binding, given, when } from "cucumber-tsflow";
+import { after, afterAll, before, beforeAll, binding, given, then, when } from "cucumber-tsflow";
 
 class Foo {
   public readonly actual = true;
 }
+
+let afterBazCount = 0;
 
 // tslint:disable-next-line:max-classes-per-file
 @binding([Foo])
@@ -33,9 +35,20 @@ export default class TestSteps {
     equal(1+1, 2, "This is true");
   }
 
-  @after()
+  @then("baz")
+  public ThenBaz(): void {
+    equal(false, false, "This is false");
+  }
+
+  @after("not @baz")
   public after() {
     equal(true, true, "It's true, I ran");
+  }
+
+  @after("@baz")
+  public afterBazOnly() {
+    ++afterBazCount;
+    equal(afterBazCount, 1, "This should only ever be one");
   }
 
   @afterAll()

--- a/cucumber-tsflow-specs/src/step_definitions/test.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/test.ts
@@ -1,5 +1,5 @@
 import { equal } from "assert";
-import { before, binding, given } from "cucumber-tsflow";
+import { after, afterAll, before, beforeAll, binding, given, when } from "cucumber-tsflow";
 
 class Foo {
   public readonly actual = true;
@@ -12,6 +12,11 @@ export default class TestSteps {
 
   private actual = false;
 
+  @beforeAll()
+  public beforeAll() {
+    console.log("I should only run once, but I don't run at all");
+  }
+
   @before()
   public before() {
     this.actual = true;
@@ -21,5 +26,20 @@ export default class TestSteps {
   public async GivenFoo(): Promise<void> {
     await equal(this.actual, true);
     await equal(this.foo.actual, true);
+  }
+
+  @when("bar")
+  public WhenBar(): void {
+    equal(1+1, 2, "This is true");
+  }
+
+  @after()
+  public after() {
+    equal(true, true, "It's true, I ran");
+  }
+
+  @afterAll()
+  public afterAll() {
+    console.log("I should only run once, but I don't run at all");
   }
 }

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -229,17 +229,17 @@ function bindHook(stepBinding: StepBinding): void {
     value: stepBinding.argsLength
   });
 
+  // build the args for the hooks
+  const hookArgs: [any, ()=>any] | [any] = [bindingFunc];
+  if (stepBinding.tag !== DEFAULT_TAG) {
+    hookArgs.unshift(String(stepBinding.tag));
+  } 
+
   if (stepBinding.bindingType & StepBindingFlags.before) {
-    if (stepBinding.tag === DEFAULT_TAG) {
-      Before(bindingFunc);
-    } else {
-      Before(String(stepBinding.tag), bindingFunc);
-    }
+    Before(...hookArgs);
   } else if (stepBinding.bindingType & StepBindingFlags.after) {
-    if (stepBinding.tag === DEFAULT_TAG) {
-      After(bindingFunc);
-    } else {
-      After(String(stepBinding.tag), bindingFunc);
-    }
-  }
+    After(...hookArgs);
+  } /* else if (stepBinding.bindingType & StepBindingFlags.afterAll) {
+    AfterAll(bindingFunc);
+  } */
 }

--- a/cucumber-tsflow/src/hook-decorators.ts
+++ b/cucumber-tsflow/src/hook-decorators.ts
@@ -26,7 +26,7 @@ export function before(tag?: string): MethodDecorator {
     };
 
     if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
+      stepBinding.tag = tag;
     }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);
@@ -59,7 +59,73 @@ export function after(tag?: string): MethodDecorator {
     };
 
     if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
+      stepBinding.tag = tag;
+    }
+
+    BindingRegistry.instance.registerStepBinding(stepBinding);
+
+    return descriptor;
+  };
+}
+
+/**
+ * A method decorator that marks the associated function as an 'Before All Scenario' step. The function is
+ * executed after each feature.
+ *
+ * @param tag An optional tag.
+ */
+export function beforeAll(tag?: string): MethodDecorator {
+  const callsite = Callsite.capture();
+
+  return <T>(
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<T>
+  ) => {
+    const stepBinding: StepBinding = {
+      stepPattern: "",
+      bindingType: StepBindingFlags.beforeAll,
+      targetPrototype: target,
+      targetPropertyKey: propertyKey,
+      argsLength: target[propertyKey].length,
+      callsite: callsite
+    };
+
+    if (tag) {
+      stepBinding.tag = tag;
+    }
+
+    BindingRegistry.instance.registerStepBinding(stepBinding);
+
+    return descriptor;
+  };
+}
+
+/**
+ * A method decorator that marks the associated function as an 'After All Scenario' step. The function is
+ * executed after each feature.
+ *
+ * @param tag An optional tag.
+ */
+export function afterAll(tag?: string): MethodDecorator {
+  const callsite = Callsite.capture();
+
+  return <T>(
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<T>
+  ) => {
+    const stepBinding: StepBinding = {
+      stepPattern: "",
+      bindingType: StepBindingFlags.afterAll,
+      targetPrototype: target,
+      targetPropertyKey: propertyKey,
+      argsLength: target[propertyKey].length,
+      callsite: callsite
+    };
+
+    if (tag) {
+      stepBinding.tag = tag;
     }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);

--- a/cucumber-tsflow/src/step-binding-flags.ts
+++ b/cucumber-tsflow/src/step-binding-flags.ts
@@ -34,6 +34,16 @@ export enum StepBindingFlags {
   after = 1 << 4,
 
   /**
+   * An 'BeforeAll' hook binding 
+   */
+  beforeAll = 1 << 5,
+
+  /**
+   * An 'AfterAll' hook binding 
+   */
+  afterAll = 1 << 6,
+
+  /**
    * All step definition bindings.
    */
   StepDefinitions = StepBindingFlags.given |
@@ -43,5 +53,5 @@ export enum StepBindingFlags {
   /**
    * All hook bindings.
    */
-  Hooks = StepBindingFlags.before | StepBindingFlags.after
+  Hooks = StepBindingFlags.before | StepBindingFlags.after | StepBindingFlags.beforeAll | StepBindingFlags.afterAll
 }


### PR DESCRIPTION
I made an attempt to add the BeforeAll and AfterAll. I came across some issues, unfortunately the hooks do not work yet. Mainly, I am having a hard time understanding how the [step-binding-flags](https://github.com/timjroberts/cucumber-js-tsflow/blob/master/cucumber-tsflow/src/step-binding-flags.ts) actually work. I simply followed the pattern and added two more flags and then added the decorators in [hook-decorators](https://github.com/timjroberts/cucumber-js-tsflow/blob/master/cucumber-tsflow/src/hook-decorators.ts)

Lastly, I simplified the tag filter on the hooks so you now must have an `@` on your tag which enables more in depth tag expressions like `not @Foo`.

Anyone see what's missing to get this to work? Help would be appreciated. 

## Related Issues

Fixes #47 
Fixes #41 

## Testing 

Since the before all and after all are supposed to run after all scenarios, I added a second scenario to the test gherkin. Then I added the before/after all hooks with some simple consol.log for now. 