### PR TITLE
allowed any tag expression in hooks

### DIFF
--- a/cucumber-tsflow-specs/features/test.feature
+++ b/cucumber-tsflow-specs/features/test.feature
@@ -3,4 +3,11 @@ Feature: Test Feature
 @foo
 Scenario: Test Scenario
     Given foo
-    
+
+@bar
+Scenario: Second Test Scenario
+    When bar
+
+@baz 
+Scenario: Test hooks here
+    Then baz

--- a/cucumber-tsflow-specs/src/step_definitions/test.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/test.ts
@@ -1,9 +1,12 @@
 import { equal } from "assert";
-import { before, binding, given } from "cucumber-tsflow";
+import { after, before, binding, given, then, when } from "cucumber-tsflow";
 
 class Foo {
   public readonly actual = true;
 }
+
+let afterBazCount = 0;
+let afterCount = 0;
 
 // tslint:disable-next-line:max-classes-per-file
 @binding([Foo])
@@ -22,4 +25,27 @@ export default class TestSteps {
     await equal(this.actual, true);
     await equal(this.foo.actual, true);
   }
+
+  @when("bar")
+  public WhenBar(): void {
+    equal(1+1, 2, "This is true");
+  }
+
+  @then("baz")
+  public ThenBaz(): void {
+    equal(false, false, "This is false");
+  }
+
+  @after("not @baz")
+  public after() {
+    ++afterCount;
+    equal((afterCount < 3), true, "It's true, I ran");
+  }
+
+  @after("@baz")
+  public afterBazOnly() {
+    ++afterBazCount;
+    equal(afterBazCount, 1, "This should only ever be one");
+  }
+
 }

--- a/cucumber-tsflow/src/hook-decorators.ts
+++ b/cucumber-tsflow/src/hook-decorators.ts
@@ -26,7 +26,7 @@ export function before(tag?: string): MethodDecorator {
     };
 
     if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
+      stepBinding.tag = tag;
     }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);
@@ -59,7 +59,7 @@ export function after(tag?: string): MethodDecorator {
     };
 
     if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
+      stepBinding.tag = tag;
     }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);


### PR DESCRIPTION
Simply made the tag adding code be like:
```ts
if (tag) {
    stepBinding.tag = tag;
}
```
Now any tag expression can be done, e.g. `@before("not @SomeTag")`

Also added a few tests to show off the tagging features. 

Fixes #45 