### PR TITLE
Fix duplicate step registration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -1,5 +1,5 @@
 import { After, Before, Given, Tag, Then, When } from "cucumber";
-import _ from "underscore";
+import * as _ from "underscore";
 
 import { BindingRegistry, DEFAULT_TAG } from "./binding-registry";
 import { ManagedScenarioContext } from "./managed-scenario-context";
@@ -158,7 +158,7 @@ function bindStepDefinition(stepBinding: StepBinding): void {
 
     return (bindingObject[
       matchingStepBindings[0].targetPropertyKey
-    ] as () => void).apply(bindingObject, arguments as any);
+    ] as () => void).apply(bindingObject, arguments);
   };
 
   Object.defineProperty(bindingFunc, "length", {
@@ -221,7 +221,7 @@ function bindHook(stepBinding: StepBinding): void {
 
     return (bindingObject[stepBinding.targetPropertyKey] as () => void).apply(
       bindingObject,
-      arguments as any
+      arguments
     );
   };
 

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -143,7 +143,7 @@ function bindStepDefinition(stepBinding: StepBinding): void {
           )} (${matchingStepBinding.callsite.toString()})\n`;
       });
 
-      return new Error(message);
+      throw new Error(message);
     }
 
     const contextTypes = bindingRegistry.getContextTypesForTarget(

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -1,5 +1,5 @@
 import { After, Before, Given, Tag, Then, When } from "cucumber";
-import * as _ from "underscore";
+import _ from "underscore";
 
 import { BindingRegistry, DEFAULT_TAG } from "./binding-registry";
 import { ManagedScenarioContext } from "./managed-scenario-context";
@@ -158,7 +158,7 @@ function bindStepDefinition(stepBinding: StepBinding): void {
 
     return (bindingObject[
       matchingStepBindings[0].targetPropertyKey
-    ] as () => void).apply(bindingObject, arguments);
+    ] as () => void).apply(bindingObject, arguments as any);
   };
 
   Object.defineProperty(bindingFunc, "length", {
@@ -221,7 +221,7 @@ function bindHook(stepBinding: StepBinding): void {
 
     return (bindingObject[stepBinding.targetPropertyKey] as () => void).apply(
       bindingObject,
-      arguments
+      arguments as any
     );
   };
 

--- a/cucumber-tsflow/src/binding-registry.ts
+++ b/cucumber-tsflow/src/binding-registry.ts
@@ -1,4 +1,4 @@
-import _ from "underscore";
+import * as _ from "underscore";
 
 import { StepBinding } from "./step-binding";
 import { ContextType, StepPattern, TagName } from "./types";

--- a/cucumber-tsflow/src/binding-registry.ts
+++ b/cucumber-tsflow/src/binding-registry.ts
@@ -1,4 +1,4 @@
-import * as _ from "underscore";
+import _ from "underscore";
 
 import { StepBinding } from "./step-binding";
 import { ContextType, StepPattern, TagName } from "./types";
@@ -131,7 +131,9 @@ export class BindingRegistry {
       tagMap.set(stepBinding.tag, stepBindings);
     }
 
-    stepBindings.push(stepBinding);
+    if (!stepBindings.some(b => isSameStepBinding(stepBinding, b))) {
+      stepBindings.push(stepBinding);
+    }
 
     // Index the step binding for the target
 
@@ -146,7 +148,17 @@ export class BindingRegistry {
       this._targetBindings.set(stepBinding.targetPrototype, targetBinding);
     }
 
-    targetBinding.stepBindings.push(stepBinding);
+    if (!targetBinding.stepBindings.some(b => isSameStepBinding(stepBinding, b))) {
+      targetBinding.stepBindings.push(stepBinding);
+    }
+
+    function isSameStepBinding(a: StepBinding, b: StepBinding) {
+      return (
+        a.callsite.filename === b.callsite.filename
+        && a.callsite.lineNumber === b.callsite.lineNumber
+        && a.stepPattern === b.stepPattern
+      );
+    }
   }
 
   /**

--- a/cucumber-tsflow/src/binding-registry.ts
+++ b/cucumber-tsflow/src/binding-registry.ts
@@ -148,15 +148,17 @@ export class BindingRegistry {
       this._targetBindings.set(stepBinding.targetPrototype, targetBinding);
     }
 
-    if (!targetBinding.stepBindings.some(b => isSameStepBinding(stepBinding, b))) {
+    if (
+      !targetBinding.stepBindings.some(b => isSameStepBinding(stepBinding, b))
+    ) {
       targetBinding.stepBindings.push(stepBinding);
     }
 
     function isSameStepBinding(a: StepBinding, b: StepBinding) {
       return (
-        a.callsite.filename === b.callsite.filename
-        && a.callsite.lineNumber === b.callsite.lineNumber
-        && a.stepPattern === b.stepPattern
+        a.callsite.filename === b.callsite.filename &&
+        a.callsite.lineNumber === b.callsite.lineNumber &&
+        String(a.stepPattern) === String(b.stepPattern)
       );
     }
   }

--- a/cucumber-tsflow/src/our-callsite.ts
+++ b/cucumber-tsflow/src/our-callsite.ts
@@ -1,4 +1,4 @@
-import * as stack from "callsite";
+import stack from "callsite";
 
 /**
  * Represents a callsite of where a step binding is being applied.

--- a/cucumber-tsflow/src/our-callsite.ts
+++ b/cucumber-tsflow/src/our-callsite.ts
@@ -1,4 +1,4 @@
-import stack from "callsite";
+import * as stack from "callsite";
 
 /**
  * Represents a callsite of where a step binding is being applied.


### PR DESCRIPTION
This fixes #52.  The root causes were:

1. The steps were being registered multiple times.
2. The "Ambiguous step definitions" error was never being displayed, due to the Error being returned instead of thrown.  This was making it appear as though steps were being ignored.

This PR fixes the "Ambiguous step definitions" error so it is now thrown.

This PR also adds a duplicate check using the Callsite's filename and lineNumber.  If the filename and lineNumber is the same, then we should assume the step file is being compiled again and we should not re-register the binding.