### PR TITLE
Upgrade the library to use Cucumber's latest package

### DIFF
--- a/cucumber-tsflow-specs/package-lock.json
+++ b/cucumber-tsflow-specs/package-lock.json
@@ -4,24 +4,130 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "cucumber-tsflow": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/cucumber-tsflow/-/cucumber-tsflow-3.2.2.tgz",
-      "integrity": "sha512-SRHCV5b0ynHdI+NCPPvhgYnY73R9vyXeJCE2aoZ66hSvYzVxbptGGhGM2UE7QD1nzlUM/DOLMeJ+DEpYoPPeHA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cucumber-tsflow/-/cucumber-tsflow-3.4.1.tgz",
+      "integrity": "sha512-cp2J4BBSdLQsHn731ML7TGaMDGfu6c3BSjQlIORJr3yQy2nMdc6btEh6/imENt7/KPa1JjjMpH7NKVHfO7A00g==",
       "requires": {
-        "callsite": "^1.0.0",
+        "callsites": "^3.1.0",
+        "log4js": "^6.3.0",
+        "source-map-support": "^0.5.19",
         "underscore": "^1.8.3"
       }
     },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
+    },
+    "debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "log4js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "requires": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.4"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "rfdc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+      "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
+        }
+      }
+    },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     }
   }
 }

--- a/cucumber-tsflow-specs/package.json
+++ b/cucumber-tsflow-specs/package.json
@@ -8,6 +8,6 @@
   "main": "./index.js",
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "cucumber-tsflow": "^3.4.1"
+    "cucumber-tsflow": "^4.0.0"
   }
 }

--- a/cucumber-tsflow/package-lock.json
+++ b/cucumber-tsflow/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cucumber-tsflow",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cucumber-tsflow/package.json
+++ b/cucumber-tsflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cucumber-tsflow",
-  "description": "Provides 'specflow' like bindings for CucumberJS in TypeScript 1.7+.",
-  "version": "3.4.1",
+  "description": "Provides 'specflow' like bindings for CucumberJS 7.0.0+ in TypeScript 1.7+.",
+  "version": "4.0.0",
   "author": "Tim Roberts <tim@timjroberts.com>",
   "license": "MIT",
   "main": "./dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,460 @@
         "minimist": "^1.2.0"
       }
     },
+    "@cucumber/create-meta": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/create-meta/-/create-meta-2.0.2.tgz",
+      "integrity": "sha512-nQoaFZVSiYa8RKAU+4wMMVK2GT/SNbHo1tNlwdEbn2auWhWt3oCisMqiQwzfgZGuKyhXAoycj0QzlGT0DRMc4A==",
+      "dev": true,
+      "requires": {
+        "@cucumber/messages": "^13.0.1",
+        "ts-node": "^9.0.0",
+        "typescript": "^4.0.2"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
+          "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          }
+        },
+        "typescript": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+          "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+          "dev": true
+        }
+      }
+    },
+    "@cucumber/cucumber": {
+      "version": "7.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-7.0.0-rc.0.tgz",
+      "integrity": "sha512-OUuFR78NB0hSuwA3tuVeshfHCVbd5yn6i8/NkftVP3QxyKD3wM01ngV4Fo/WckLffTIj0RCHEPaIV80icv2jgQ==",
+      "dev": true,
+      "requires": {
+        "@cucumber/create-meta": "^2.0.2",
+        "@cucumber/cucumber-expressions": "^10.3.0",
+        "@cucumber/gherkin": "^15.0.2",
+        "@cucumber/messages": "^13.0.1",
+        "@cucumber/query": "^7.0.0",
+        "@cucumber/tag-expressions": "^2.0.4",
+        "assertion-error-formatter": "^3.0.0",
+        "bluebird": "^3.7.2",
+        "capital-case": "^1.0.3",
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0",
+        "commander": "^5.0.0",
+        "duration": "^0.2.2",
+        "durations": "^3.4.2",
+        "figures": "^3.2.0",
+        "glob": "^7.1.6",
+        "indent-string": "^4.0.0",
+        "is-generator": "^1.0.3",
+        "is-stream": "^2.0.0",
+        "knuth-shuffle-seeded": "^1.0.6",
+        "lodash": "^4.17.20",
+        "mz": "^2.7.0",
+        "progress": "^2.0.3",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.17.0",
+        "stack-chain": "^2.0.0",
+        "stacktrace-js": "^2.0.2",
+        "string-argv": "^0.3.1",
+        "tmp": "^0.2.1",
+        "util-arity": "^1.1.0",
+        "verror": "^1.10.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "assertion-error-formatter": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-3.0.0.tgz",
+          "integrity": "sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ==",
+          "dev": true,
+          "requires": {
+            "diff": "^4.0.1",
+            "pad-right": "^0.2.2",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "bluebird": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+          "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+          "dev": true
+        },
+        "cli-table3": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+          "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+          "dev": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "error-stack-parser": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+          "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+          "dev": true,
+          "requires": {
+            "stackframe": "^1.1.1"
+          }
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        },
+        "stack-generator": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+          "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+          "dev": true,
+          "requires": {
+            "stackframe": "^1.1.1"
+          }
+        },
+        "stackframe": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+          "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+          "dev": true
+        },
+        "stacktrace-gps": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+          "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "stackframe": "^1.1.1"
+          }
+        },
+        "stacktrace-js": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+          "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+          "dev": true,
+          "requires": {
+            "error-stack-parser": "^2.0.6",
+            "stack-generator": "^2.0.5",
+            "stacktrace-gps": "^3.0.4"
+          }
+        },
+        "string-argv": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+          "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "@cucumber/cucumber-expressions": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-10.3.0.tgz",
+      "integrity": "sha512-ZoDb6UPXPmYnRpAye2AoSO7T2j345MDH+D64ikLlXU4WT+83fvma7ULrx3B9IfNlIQOKuE2dodi4uPu95uPjbA==",
+      "dev": true,
+      "requires": {
+        "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.4.0"
+      }
+    },
+    "@cucumber/gherkin": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-15.0.2.tgz",
+      "integrity": "sha512-E8GIulakxjXPlGatW6DxYQ1jJSHvT9mDLginqe7AkjyIjBuddQvXFShI/4fdYa6XaF3gO4ybhQvHtcza/1ob/Q==",
+      "dev": true,
+      "requires": {
+        "@cucumber/messages": "^13.0.1",
+        "@teppeis/multimaps": "^1.1.0",
+        "commander": "^6.0.0",
+        "source-map-support": "^0.5.19"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+          "dev": true
+        }
+      }
+    },
+    "@cucumber/messages": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-13.1.0.tgz",
+      "integrity": "sha512-C/ViAh7T0mYhldS9TEvpK/VLWEhdYhzDkDN4m6x71OzRDtzbXba6/qnqo8+cJ+g8w8oihLh2fjvbDPWmf2P8aA==",
+      "dev": true,
+      "requires": {
+        "@types/uuid": "^8.3.0",
+        "protobufjs": "^6.10.1",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "dev": true
+        }
+      }
+    },
+    "@cucumber/query": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-7.0.0.tgz",
+      "integrity": "sha512-14pdaDXOgKQ2liNdj75zUo14b8A8JDHGLaypOEfgM450/X9gNqwv3OmeDuiKtelUuwM7AYRdIv4eVLKArAdrJA==",
+      "dev": true,
+      "requires": {
+        "@cucumber/gherkin": "^15.0.0",
+        "@cucumber/messages": "^13.0.1",
+        "@teppeis/multimaps": "^1.1.0"
+      }
+    },
+    "@cucumber/tag-expressions": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-2.0.4.tgz",
+      "integrity": "sha512-HiNncmg/gS34yNpMFAeoIyUHqLFFN92MXIj3rs+BKo7vn16SxvYsigDvd2PAHyjSIThsp9TO1XDtl0SLKVB58g==",
+      "dev": true
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -2515,6 +2969,70 @@
         "@types/node": ">= 8"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -2541,6 +3059,12 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@teppeis/multimaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-1.1.0.tgz",
+      "integrity": "sha512-YgANgfYU7LqgaLkGPWSTiwu2qcuhj0IOvj+kRwDFjAVbiEXT7ZQLPaFfmrAAN/Fa+tvwy1aYFd0RdT7lMO1Msw==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -2589,12 +3113,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/cucumber": {
-      "version": "4.0.4",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/@types/cucumber/-/cucumber-4.0.4.tgz",
-      "integrity": "sha1-pt/ICtPg6MvaZajSLXaQ34gBc8c=",
-      "dev": true
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -2639,6 +3157,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2679,6 +3203,12 @@
       "version": "1.8.8",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/@types/underscore/-/underscore-1.8.8.tgz",
       "integrity": "sha1-UQ/hyl5/qH/M1AW5qLVm1CC8PRs=",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -2939,17 +3469,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "assertion-error-formatter": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
-      "integrity": "sha1-a73/rsji+p4rDrFYv+NTEy18Cps=",
-      "dev": true,
-      "requires": {
-        "diff": "^3.0.0",
-        "pad-right": "^0.2.2",
-        "repeat-string": "^1.6.1"
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -3150,16 +3669,6 @@
       "requires": {
         "babel-plugin-jest-hoist": "^26.1.0",
         "babel-preset-current-node-syntax": "^0.1.2"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
       }
     },
     "balanced-match": {
@@ -3458,12 +3967,6 @@
         "caller-callsite": "^2.0.0"
       }
     },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -3479,6 +3982,44 @@
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
+      }
+    },
+    "capital-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
+      "integrity": "sha512-OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0",
+        "upper-case-first": "^2.0.1"
+      },
+      "dependencies": {
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "no-case": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+          "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
       }
     },
     "capture-exit": {
@@ -3561,50 +4102,6 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-table3": {
-      "version": "0.5.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/cli-table3/-/cli-table3-0.5.1.tgz",
-      "integrity": "sha1-AlI3LZTfxA29jfBgBfSPMfZW8gI=",
-      "dev": true,
-      "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "cli-truncate": {
@@ -3726,12 +4223,6 @@
       "version": "1.1.3",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.3.2",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha1-Lfj/Vz378lWvVi+M5xgda5caNZs=",
       "dev": true
     },
     "columnify": {
@@ -4116,12 +4607,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha1-+XJgj/DOrWi4QaFqky0LGDeRgU4=",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4175,58 +4660,6 @@
           "dev": true
         }
       }
-    },
-    "cucumber": {
-      "version": "5.0.2",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/cucumber/-/cucumber-5.0.2.tgz",
-      "integrity": "sha1-/97qC0fq8hpj3ttJzYgEJfLX61I=",
-      "dev": true,
-      "requires": {
-        "assertion-error-formatter": "^2.0.1",
-        "babel-runtime": "^6.11.6",
-        "bluebird": "^3.4.1",
-        "cli-table3": "^0.5.1",
-        "colors": "^1.1.2",
-        "commander": "^2.9.0",
-        "cross-spawn": "^6.0.5",
-        "cucumber-expressions": "^6.0.0",
-        "cucumber-tag-expressions": "^1.1.1",
-        "duration": "^0.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "figures": "2.0.0",
-        "gherkin": "^5.0.0",
-        "glob": "^7.0.0",
-        "indent-string": "^3.1.0",
-        "is-generator": "^1.0.2",
-        "is-stream": "^1.1.0",
-        "knuth-shuffle-seeded": "^1.0.6",
-        "lodash": "^4.17.10",
-        "mz": "^2.4.0",
-        "progress": "^2.0.0",
-        "resolve": "^1.3.3",
-        "serialize-error": "^2.1.0",
-        "stack-chain": "^2.0.0",
-        "stacktrace-js": "^2.0.0",
-        "string-argv": "0.1.1",
-        "title-case": "^2.1.1",
-        "util-arity": "^1.0.2",
-        "verror": "^1.9.0"
-      }
-    },
-    "cucumber-expressions": {
-      "version": "6.0.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/cucumber-expressions/-/cucumber-expressions-6.0.1.tgz",
-      "integrity": "sha1-R8nFc3gcL/ch161bLNHJf0OZq44=",
-      "dev": true,
-      "requires": {
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.2.0"
-      }
-    },
-    "cucumber-tag-expressions": {
-      "version": "1.1.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/cucumber-tag-expressions/-/cucumber-tag-expressions-1.1.1.tgz",
-      "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo=",
-      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4601,6 +5034,12 @@
         "es5-ext": "~0.10.46"
       }
     },
+    "durations": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/durations/-/durations-3.4.2.tgz",
+      "integrity": "sha512-V/lf7y33dGaypZZetVI1eu7BmvkbC4dItq12OElLRpKuaU5JxQstV2zHwLv8P7cNbQ+KL1WD80zMCTx5dNC4dg==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4666,15 +5105,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "error-stack-parser": {
-      "version": "2.0.2",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-      "integrity": "sha1-Sujbqiv5CotFBwe5FJ3KvKE1Ug0=",
-      "dev": true,
-      "requires": {
-        "stackframe": "^1.0.4"
       }
     },
     "es-abstract": {
@@ -5530,12 +5960,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "gherkin": {
-      "version": "5.1.0",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/gherkin/-/gherkin-5.1.0.tgz",
-      "integrity": "sha1-aEu7A63STq9731RPWAM+so+zxtU=",
-      "dev": true
     },
     "git-raw-commits": {
       "version": "2.0.0",
@@ -9147,6 +9571,12 @@
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -9757,6 +10187,12 @@
         }
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -9766,12 +10202,6 @@
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
-    },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -10319,15 +10749,6 @@
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
-    },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
-      "dev": true,
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -11064,12 +11485,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha1-ySQhaTQrHCnSdYiclXNGIbGVLjE=",
-      "dev": true
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -11110,6 +11525,35 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
+    },
+    "protobufjs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
+          "dev": true
+        }
+      }
     },
     "protocols": {
       "version": "1.4.7",
@@ -11375,12 +11819,6 @@
           "dev": true
         }
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
-      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -11668,12 +12106,6 @@
       "version": "1.0.0",
       "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
-    },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
       "dev": true
     },
     "set-blocking": {
@@ -12085,15 +12517,6 @@
       "integrity": "sha1-1z0Rcq+JVl8HQ4tbzAhoMbZomy0=",
       "dev": true
     },
-    "stack-generator": {
-      "version": "2.0.3",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/stack-generator/-/stack-generator-2.0.3.tgz",
-      "integrity": "sha1-u3Q4XGf/xMzzxN7lgxgy1OUJyKA=",
-      "dev": true,
-      "requires": {
-        "stackframe": "^1.0.4"
-      }
-    },
     "stack-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
@@ -12109,41 +12532,6 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
-      }
-    },
-    "stackframe": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/stackframe/-/stackframe-1.0.4.tgz",
-      "integrity": "sha1-NXskqZL5Qny6a1RdlqFO0svKGHs=",
-      "dev": true
-    },
-    "stacktrace-gps": {
-      "version": "3.0.2",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
-      "integrity": "sha1-M/i6pEZzI6sr0YFu+ieZQrpDHMw=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.0.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true
-        }
-      }
-    },
-    "stacktrace-js": {
-      "version": "2.0.0",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
-      "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
-      "dev": true,
-      "requires": {
-        "error-stack-parser": "^2.0.1",
-        "stack-generator": "^2.0.1",
-        "stacktrace-gps": "^3.0.1"
       }
     },
     "staged-git-files": {
@@ -12193,12 +12581,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
-    },
-    "string-argv": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/string-argv/-/string-argv-0.1.1.tgz",
-      "integrity": "sha1-Zr1a44I3COqhkW+lQScDFQ1N368=",
       "dev": true
     },
     "string-length": {
@@ -12523,16 +12905,6 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
-      }
-    },
-    "title-case": {
-      "version": "2.1.1",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/title-case/-/title-case-2.1.1.tgz",
-      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.0.3"
       }
     },
     "tmp": {
@@ -12881,11 +13253,22 @@
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
     },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://artifactory.cloud.capitalone.com:443/artifactory/api/npm/npm-internalfacing/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
+    "upper-case-first": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz",
+      "integrity": "sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
+        }
+      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,17 @@
     ]
   },
   "devDependencies": {
-    "@types/cucumber": "^4.0.4",
+    "@cucumber/cucumber": "^7.0.0-rc.0",
     "@types/node": "10.7.1",
     "@types/underscore": "1.8.8",
-    "cucumber": "^5.0.2",
     "husky": "^1.1.3",
+    "jest": "^26.1.0",
     "lerna": "^3.22.1",
     "lint-staged": "^8.0.4",
     "prettier": "^1.15.2",
+    "ts-node": "^8.10.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.9.7",
-    "jest": "^26.1.0",
-    "ts-node": "^8.10.2"
+    "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/cucumber/cucumber-js/issues/1369, a pre-release for `cucumber-js` (package renamed `@cucumber/cucumber`) has been released.

This pull-request proposes to release a new major version of this one, using this new package.