### PR TITLE
Use non-default logger category to avoid changing default category's logging level

### DIFF
--- a/cucumber-tsflow/src/logger.ts
+++ b/cucumber-tsflow/src/logger.ts
@@ -1,5 +1,5 @@
 import * as log4js from "log4js";
-const logger = log4js.getLogger();
+const logger = log4js.getLogger("cucumber-js.tsflow");
 
 logger.level = "debug"; // default level is OFF - which means no logs at all.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "lerna bootstrap",
     "precommit": "lint-staged && npm test",
     "pretest": "npm run build",
-    "test": "cucumber-js --tags 'not @wip' --require cucumber-tsflow-specs/dist cucumber-tsflow-specs",
+    "test": "cucumber-js --tags \"not @wip\" --require cucumber-tsflow-specs/dist cucumber-tsflow-specs",
     "set-packageversion": "node .build/setPackageVersion.js"
   },
   "lint-staged": {


### PR DESCRIPTION
Getting logger without category means that logger with `default` category is returned.
When `level` for such logger is set, it means that the level for the whole category gets changed: https://github.com/log4js-node/log4js-node/blob/master/lib/logger.js#L56
So, if you don't have a category-specific logger configuration, then log level for all loggers gets changed (bacause they use `default` category's configuration).

In our case we specify categories for our loggers but we don't use category-specific logger configurations (so, we use our `default` category's configuration which allows `trace` level). Many of our loggers use `trace` level to output some specific information and those messages are not visible because `tsflow` sets `debug` level for default configuration.

Another change in this PR is the usage of double quotes instead of single quotes in `test` script to allow to run the script on Windows.