### PR TITLE
Drop custom tag processing in favor of cucumber native tags

### DIFF
--- a/cucumber-tsflow-specs/features/tagging-test.feature
+++ b/cucumber-tsflow-specs/features/tagging-test.feature
@@ -19,6 +19,7 @@ Scenario: Test step definitions with tags
   will be picked as candidate for execution.
 
     Given some step to be executed with tag
+    And some step to be executed without a tag
     When the condition is right with tag
     Then we can see the result correctly with tag
 

--- a/cucumber-tsflow-specs/src/step_definitions/tag-test.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/tag-test.ts
@@ -5,11 +5,17 @@ import expect from "expect";
 export default class TestSteps {
   private whenIsCalled = false;
   private givenIsCalled = false;
+  private givenWithoutTagCalled = false;
   private thenIsCalled = false;
 
   @given(/^some step to be executed with tag$/, "@tag2")
   public givenSomeStepTobeExecuted() {
     this.givenIsCalled = true;
+  }
+
+  @given(/^some step to be executed without a tag$/, "not @tag1")
+  public givenSomeStepThatNegatesATag() {
+    this.givenWithoutTagCalled = true;
   }
 
   @when(/^the condition is right with tag$/, "@tag2")
@@ -26,6 +32,7 @@ export default class TestSteps {
   public afterTag() {
     expect(this.whenIsCalled).toBe(true);
     expect(this.givenIsCalled).toBe(true);
+    expect(this.givenWithoutTagCalled).toBe(true);
     expect(this.thenIsCalled).toBe(true);
     // tslint:disable-next-line:no-console
     console.log("@tagging afterTag method is called");

--- a/cucumber-tsflow/src/binding-registry.ts
+++ b/cucumber-tsflow/src/binding-registry.ts
@@ -1,7 +1,7 @@
 import * as _ from "underscore";
 
 import { StepBinding } from "./step-binding";
-import { ContextType, StepPattern, TagName } from "./types";
+import { ContextType, StepPattern } from "./types";
 
 /**
  * Describes the binding metadata that is associated with a binding class.
@@ -32,7 +32,7 @@ export const DEFAULT_TAG: string = "*";
  * A metadata registry that captures information about bindings and their bound step bindings.
  */
 export class BindingRegistry {
-  private _bindings = new Map<StepPattern, Map<TagName, StepBinding[]>>();
+  private _bindings = new Map<StepPattern, StepBinding[]>();
   private _targetBindings = new Map<any, TargetBinding>();
 
   /**
@@ -115,20 +115,12 @@ export class BindingRegistry {
       ? stepBinding.stepPattern.toString()
       : DEFAULT_STEP_PATTERN;
 
-    let tagMap = this._bindings.get(stepPattern);
-
-    if (!tagMap) {
-      tagMap = new Map<TagName, StepBinding[]>();
-
-      this._bindings.set(stepPattern, tagMap);
-    }
-
-    let stepBindings = tagMap.get(stepBinding.tag);
+    let stepBindings = this._bindings.get(stepPattern);
 
     if (!stepBindings) {
       stepBindings = [];
 
-      tagMap.set(stepBinding.tag, stepBindings);
+      this._bindings.set(stepPattern, stepBindings);
     }
 
     if (!stepBindings.some(b => isSameStepBinding(stepBinding, b))) {
@@ -185,49 +177,10 @@ export class BindingRegistry {
    * Retrieves the step bindings for a given step pattern and collection of tag names.
    *
    * @param stepPattern The step pattern to search.
-   * @param tags An array of [[TagName]] to search.
    *
    * @returns An array of [[StepBinding]] that map to the given step pattern and set of tag names.
    */
-  public getStepBindings(
-    stepPattern: StepPattern,
-    tags: TagName[]
-  ): StepBinding[] {
-    const tagMap = this._bindings.get(stepPattern);
-
-    if (!tagMap) {
-      return [];
-    }
-
-    const matchingStepBindings = this.mapTagNamesToStepBindings(tags, tagMap);
-
-    if (matchingStepBindings.length > 0) {
-      return matchingStepBindings;
-    }
-
-    return this.mapTagNamesToStepBindings(["*"], tagMap);
-  }
-
-  /**
-   * Maps an array of tag names to an array of associated step bindings.
-   *
-   * @param tags An array of [[TagName]].
-   * @param tagMap The map of [[TagName]] -> [[StepBinding]] to use when mapping.
-   *
-   * @returns An array of [[StepBinding]].
-   */
-  private mapTagNamesToStepBindings(
-    tags: TagName[],
-    tagMap: Map<TagName, StepBinding[]>
-  ): StepBinding[] {
-    const matchingStepBindings: Array<StepBinding|undefined> = _.flatten(
-      _.map(tags, tag => tagMap.get(tag))
-    );
-
-    return _.reject(
-      matchingStepBindings,
-      stepBinding => stepBinding === undefined
-    // Cast is safe because this operation removed all the undefined elements.
-    ) as StepBinding[];
+  public getStepBindings(stepPattern: StepPattern): StepBinding[] {
+    return this._bindings.get(stepPattern) ?? [];
   }
 }

--- a/cucumber-tsflow/src/hook-decorators.ts
+++ b/cucumber-tsflow/src/hook-decorators.ts
@@ -1,6 +1,7 @@
 import { BindingRegistry } from "./binding-registry";
 import { Callsite } from "./our-callsite";
 import { StepBinding, StepBindingFlags } from "./step-binding";
+import { normalizeTag } from "./tag-normalization";
 
 /**
  * A method decorator that marks the associated function as a 'Before Scenario' step. The function is
@@ -22,12 +23,9 @@ export function before(tag?: string): MethodDecorator {
       targetPrototype: target,
       targetPropertyKey: propertyKey,
       argsLength: target[propertyKey].length,
+      tag: normalizeTag(tag),
       callsite: callsite
     };
-
-    if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
-    }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);
 
@@ -55,12 +53,9 @@ export function after(tag?: string): MethodDecorator {
       targetPrototype: target,
       targetPropertyKey: propertyKey,
       argsLength: target[propertyKey].length,
+      tag: normalizeTag(tag),
       callsite: callsite
     };
-
-    if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
-    }
 
     BindingRegistry.instance.registerStepBinding(stepBinding);
 

--- a/cucumber-tsflow/src/step-definition-decorators.ts
+++ b/cucumber-tsflow/src/step-definition-decorators.ts
@@ -1,6 +1,7 @@
 import { BindingRegistry } from "./binding-registry";
 import { Callsite } from "./our-callsite";
 import { StepBinding, StepBindingFlags } from "./step-binding";
+import { normalizeTag } from "./tag-normalization";
 
 /**
  * A method decorator that marks the associated function as a 'Given' step.
@@ -27,12 +28,9 @@ export function given(
       targetPrototype: target,
       targetPropertyKey: propertyKey,
       argsLength: target[propertyKey].length,
+      tag: normalizeTag(tag),
       callsite: callsite
     };
-
-    if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
-    }
 
     if (timeout) {
       stepBinding.timeout = timeout;
@@ -69,12 +67,9 @@ export function when(
       targetPrototype: target,
       targetPropertyKey: propertyKey,
       argsLength: target[propertyKey].length,
+      tag: normalizeTag(tag),
       callsite: callsite
     };
-
-    if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
-    }
 
     if (timeout) {
       stepBinding.timeout = timeout;
@@ -111,12 +106,9 @@ export function then(
       targetPrototype: target,
       targetPropertyKey: propertyKey,
       argsLength: target[propertyKey].length,
+      tag: normalizeTag(tag),
       callsite: callsite
     };
-
-    if (tag) {
-      stepBinding.tag = tag[0] === "@" ? tag : `@${tag}`;
-    }
 
     if (timeout) {
       stepBinding.timeout = timeout;

--- a/cucumber-tsflow/src/tag-normalization.ts
+++ b/cucumber-tsflow/src/tag-normalization.ts
@@ -1,0 +1,9 @@
+import * as _ from "underscore";
+
+export function normalizeTag(tag?: string): string | undefined {
+  return tag === undefined || tag.includes('@')
+    // Tag is not provided or already includes a @
+    ? tag
+    // If a tag doesn't include any @, for compatibility, prefix it with a @
+    : `@${tag}`;
+}


### PR DESCRIPTION
This maintains compatibility with existing tags that don't have the `@` prefix and neither are cucumber tag expressions