### PR TITLE
Expose accessor to bound context types from World object

### DIFF
--- a/cucumber-tsflow-specs/features/external-context-extraction.feature
+++ b/cucumber-tsflow-specs/features/external-context-extraction.feature
@@ -125,3 +125,79 @@ Feature: Extracing context objects from World externally
             .Cucumber-style step. State is "decorator-style before"
             .Decorator-style step. State is "cucumber-style step"
             """
+
+    Scenario: Share state between underlying cucumber functionality and TSFlow functionality
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario before year 2k
+                Given a step for 1999-03-04T21:43:54Z
+              @y2k
+              Scenario: scenario after year 2k
+                Given a step for 2023-09-13T12:34:56.789Z
+            """
+        And a file named "support/state.ts" with:
+            """ts
+            export class State {
+                public maxDate = new Date('2000-01-01');
+            }
+            """
+        And a file named "step_definitions/a.ts" with:
+            """ts
+            import {State} from '../support/state';
+            import {defineParameterType} from '@cucumber/cucumber';
+            import {ensureWorldIsInitialized,getBindingFromWorld} from 'cucumber-tsflow';
+
+            ensureWorldIsInitialized();
+
+            defineParameterType({
+              name: 'datetime',
+              regexp: /[+-]?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z/,
+              preferForRegexpMatch: true,
+              useForSnippets: true,
+              transformer: function (datetime): Date {
+                const state = getBindingFromWorld(this, State);
+
+                const date = new Date(datetime);
+
+                console.log(`Parsing date up to ${state.maxDate.toISOString()}`);
+
+                if (state.maxDate.valueOf() < date.valueOf()) {
+                    throw new Error('Date after maximum date.');
+                }
+
+                return new Date(datetime)
+              }
+            });
+            """
+        And a file named "step_definitions/b.ts" with:
+            """ts
+            import {State} from '../support/state';
+            import {binding, before, given} from 'cucumber-tsflow';
+
+            @binding([State])
+            class Steps {
+                public constructor(private readonly state: State) {}
+
+                @before({tag: '@y2k'})
+                public before() {
+                    this.state.maxDate = new Date('3000-01-01');
+                }
+
+                @given('a step for {datetime}')
+                public step(datetime: Date) {
+                    console.log(`Step received a ${datetime.constructor.name}: ${datetime.toISOString()}`);
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output contains text:
+            """
+            .Parsing date up to 2000-01-01T00:00:00.000Z
+            Step received a Date: 1999-03-04T21:43:54.000Z
+            ....Parsing date up to 3000-01-01T00:00:00.000Z
+            Step received a Date: 2023-09-13T12:34:56.789Z
+            """

--- a/cucumber-tsflow-specs/features/external-context-extraction.feature
+++ b/cucumber-tsflow-specs/features/external-context-extraction.feature
@@ -1,0 +1,74 @@
+Feature: Extracing context objects from World externally
+
+    Scenario: Initializing a state from a first bound externally
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario a
+                Given a cucumber-style step is called
+                And a decorator-style step is called
+            """
+        And a file named "support/state.ts" with:
+            """ts
+            export class State {
+                public constructor() {
+                  console.log('State has been initialized');
+                }
+
+                public value: string = "initial value";
+            }
+            """
+        And a file named "step_definitions/a.ts" with:
+            """ts
+            import {State} from '../support/state';
+            import {Before, Given} from '@cucumber/cucumber';
+            import {getBindingFromWorld} from 'cucumber-tsflow';
+
+            Before(function() {
+              const state = getBindingFromWorld(this, State);
+
+              console.log(`Cucumber-style before. State is "${state.value}"`);
+
+              state.value = 'cucumber-style before';
+            });
+
+            Given('a cucumber-style step is called', function() {
+              const state = getBindingFromWorld(this, State);
+
+              console.log(`Cucumber-style step. State is "${state.value}"`);
+
+              state.value = 'cucumber-style step';
+            });
+            """
+        And a file named "step_definitions/b.ts" with:
+            """ts
+            import {State} from '../support/state';
+            import {binding, before, given} from 'cucumber-tsflow';
+
+            @binding([State])
+            class Steps {
+                public constructor(private readonly state: State) {}
+
+                @before()
+                public step() {
+                    console.log(`Decorator-style before. State is "${this.state.value}"`);
+
+                    this.state.value = 'decorator-style before';
+                }
+
+                @given('a decorator-style step is called')
+                public step() {
+                    console.log(`Decorator-style step. State is "${this.state.value}"`);
+
+                    this.state.value = 'decorator-style step';
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output contains text:
+            """
+            aaasdasdasdad
+            """

--- a/cucumber-tsflow-specs/features/external-context-extraction.feature
+++ b/cucumber-tsflow-specs/features/external-context-extraction.feature
@@ -1,6 +1,53 @@
 Feature: Extracing context objects from World externally
 
-    Scenario: Initializing a state from a first bound externally
+    Scenario: Failing to retrieve state from a non-initialized World object
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario a
+                Given a step
+            """
+        And a file named "support/state.ts" with:
+            """ts
+            export class State {
+                public constructor() {
+                  console.log('State has been initialized');
+                }
+
+                public value: string = "initial value";
+            }
+            """
+        And a file named "step_definitions/a.ts" with:
+            """ts
+            import {State} from '../support/state';
+            import {Before, Given} from '@cucumber/cucumber';
+            import {getBindingFromWorld} from 'cucumber-tsflow';
+
+            Before(function() {
+              const state = getBindingFromWorld(this, State);
+
+              console.log(`Cucumber-style before. State is "${state.value}"`);
+
+              state.value = 'cucumber-style before';
+            });
+
+            Given('a step', function() {
+              const state = getBindingFromWorld(this, State);
+
+              console.log(`Cucumber-style step. State is "${state.value}"`);
+
+              state.value = 'cucumber-style step';
+            });
+            """
+        When I run cucumber-js
+        Then it fails
+        And the output contains text:
+            """
+            Before # step_definitions/a.ts:5
+                   Error: Scenario context have not been initialized in the provided World object.
+            """
+
+    Scenario: Sharing a state between native Cucumber and Decorator-style steps
         Given a file named "features/a.feature" with:
             """feature
             Feature: some feature
@@ -22,7 +69,9 @@ Feature: Extracing context objects from World externally
             """ts
             import {State} from '../support/state';
             import {Before, Given} from '@cucumber/cucumber';
-            import {getBindingFromWorld} from 'cucumber-tsflow';
+            import {ensureWorldIsInitialized,getBindingFromWorld} from 'cucumber-tsflow';
+
+            ensureWorldIsInitialized();
 
             Before(function() {
               const state = getBindingFromWorld(this, State);
@@ -50,7 +99,7 @@ Feature: Extracing context objects from World externally
                 public constructor(private readonly state: State) {}
 
                 @before()
-                public step() {
+                public before() {
                     console.log(`Decorator-style before. State is "${this.state.value}"`);
 
                     this.state.value = 'decorator-style before';
@@ -70,5 +119,9 @@ Feature: Extracing context objects from World externally
         Then it passes
         And the output contains text:
             """
-            aaasdasdasdad
+            .State has been initialized
+            Cucumber-style before. State is "initial value"
+            .Decorator-style before. State is "cucumber-style before"
+            .Cucumber-style step. State is "decorator-style before"
+            .Decorator-style step. State is "cucumber-style step"
             """

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -18,6 +18,7 @@ import { BindingRegistry, DEFAULT_TAG } from "./binding-registry";
 import logger from "./logger";
 import {
   ManagedScenarioContext,
+  ScenarioContext,
   ScenarioInfo,
 } from "./managed-scenario-context";
 import {
@@ -101,6 +102,26 @@ export function binding(requiredContextTypes?: ContextType[]): TypeDecorator {
       }
     }
   };
+}
+
+function getContextFromWorld(world: World): ScenarioContext {
+    const context: unknown = (world as Record<string, any>)[SCENARIO_CONTEXT_SLOTNAME];
+
+    if (context instanceof ManagedScenarioContext) {
+      return context;
+    }
+
+    throw new Error('Scenario context have not been initialized in the provided World object.');
+}
+
+export function getBindingFromWorld<T extends ContextType>( world: World, contextType: T): InstanceType<T> {
+  const context = getContextFromWorld(world);
+
+  return context.getContextInstance(contextType);
+}
+
+export function ensureWorldIsInitialized() {
+  ensureSystemBindings();
 }
 
 /**

--- a/cucumber-tsflow/src/managed-scenario-context.ts
+++ b/cucumber-tsflow/src/managed-scenario-context.ts
@@ -39,6 +39,21 @@ export class ManagedScenarioContext implements ScenarioContext {
   /**
    * @internal
    */
+  public getContextInstance(contextType: ContextType) {
+      return this.getOrActivateObject(contextType.prototype, () => {
+        if (isProvidedContextType(contextType)) {
+          throw new Error(
+            `The requested type "${contextType.name}" should be provided by cucumber-tsflow, but was not registered. Please report a bug.`
+          );
+        }
+
+        return new contextType();
+      });
+  }
+
+  /**
+   * @internal
+   */
   public addExternalObject(value: unknown) {
     if (value == null) {
       return;
@@ -65,17 +80,7 @@ export class ManagedScenarioContext implements ScenarioContext {
       return new (targetPrototype.constructor as any)(...args);
     };
 
-    const contextObjects = _.map(contextTypes, (contextType) =>
-      this.getOrActivateObject(contextType.prototype, () => {
-        if (isProvidedContextType(contextType)) {
-          throw new Error(
-            `The requested type "${contextType.name}" should be provided by cucumber-tsflow, but was not registered. Please report a bug.`
-          );
-        }
-
-        return new contextType();
-      })
-    );
+    const contextObjects = _.map(contextTypes, this.getContextInstance.bind(this));
 
     return invokeBindingConstructor(contextObjects);
   }


### PR DESCRIPTION
Allows sharing instances of context types between native Cucumber callbacks (steps, hooks, customization APIs) and decorator style callbacks as provided by `cucumber-tsflow`.

Provides an escape-hatch for APIs that don't have a decorator-style counterpart, like `defineParameterType` as noted on #125.