### PR TITLE
Add support for extra hook options

### DIFF
--- a/cucumber-tsflow-specs/features/hooks.feature
+++ b/cucumber-tsflow-specs/features/hooks.feature
@@ -201,6 +201,48 @@ Feature: Support for Cucumber hooks
             .hook two has executed
             """
 
+    @oldApis
+    Scenario: Attempting to bind named hooks with old cucumber
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: Feature
+                Scenario: example
+                    Given a step
+            """
+        And a file named "step_definitions/steps.ts" with:
+            """ts
+            import {binding, given, before, after} from 'cucumber-tsflow';
+
+            @binding()
+            class Steps {
+                private state = 'hook has not executed';
+
+                @before({name: 'setup environment'})
+                public before() {
+                    this.state = 'before hook executed';
+                }
+
+                @given("a step")
+                public given() {
+                    console.log(this.state);
+                    this.state = 'step has executed';
+                }
+
+                @after({name: 'tear down environment'})
+                public after() {
+                    console.log(this.state);
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it fails
+        And the error output contains text:
+            """
+            Object literal may only specify known properties, and 'name' does not exist in type 'HookOptions'.
+            """
+
     @newApis
     Scenario: Binding named hooks
         Given a file named "features/a.feature" with:

--- a/cucumber-tsflow-specs/features/hooks.feature
+++ b/cucumber-tsflow-specs/features/hooks.feature
@@ -200,3 +200,43 @@ Feature: Support for Cucumber hooks
             .step has executed
             .hook two has executed
             """
+
+    @newApis
+    Scenario: Binding named hooks
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: Feature
+                Scenario: example
+                    Given a step
+            """
+        And a file named "step_definitions/steps.ts" with:
+            """ts
+            import {binding, given, before, after} from 'cucumber-tsflow';
+
+            @binding()
+            class Steps {
+                private state = 'hook has not executed';
+
+                @before({name: 'setup environment'})
+                public before() {
+                    this.state = 'before hook executed';
+                }
+
+                @given("a step")
+                public given() {
+                    console.log(this.state);
+                    this.state = 'step has executed';
+                }
+
+                @after({name: 'tear down environment'})
+                public after() {
+                    console.log(this.state);
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the hook "setup environment" was executed on scenario "example"
+        And the hook "tear down environment" was executed on scenario "example"

--- a/cucumber-tsflow-specs/src/step_definitions/scenario_steps.ts
+++ b/cucumber-tsflow-specs/src/step_definitions/scenario_steps.ts
@@ -1,5 +1,6 @@
 import { DataTable } from "@cucumber/cucumber";
 import * as messages from "@cucumber/messages";
+import assert from 'assert';
 import { binding, then } from "cucumber-tsflow";
 import expect from "expect";
 import { Extractor } from "../support/helpers";
@@ -108,6 +109,14 @@ class ScenarioSteps {
     );
 
     expect(attachments).toStrictEqual([]);
+  }
+
+  @then("the hook {string} was executed on scenario {string}")
+  public checkNamedHookExecution(hookName: string, scenarioName: string) {
+    const hook = this.runner.extractor.getHookByName(hookName);
+    const executions = this.runner.extractor.getHookExecutions(scenarioName, hook.id);
+
+    assert(executions.length === 1, `Hook ${hookName} executed ${executions.length} times on scenario "${scenarioName}"`);
   }
 }
 

--- a/cucumber-tsflow-specs/src/support/helpers.ts
+++ b/cucumber-tsflow-specs/src/support/helpers.ts
@@ -92,6 +92,23 @@ export class Extractor {
     return this.getPickleStepByStepText(pickle, gherkinDocument, stepText);
   }
 
+  public getHookByName(hookName: string,): messages.Hook {
+    const hookEnvelope = this.envelopes.find(({hook}) => (
+        hook?.name === hookName
+    ))
+
+    assert.ok(hookEnvelope, `Unknown hook ${hookName}`);
+
+    return hookEnvelope.hook!;
+  }
+
+  public getHookExecutions(pickleName: string, hookId: string): messages.TestStep[] {
+    const pickle = this.getPickle(pickleName);
+    const testCase = this.getTestCase(pickle.id);
+
+    return testCase.testSteps.filter(step => step.hookId === hookId)
+  }
+
   public getTestCaseResult(pickleName: string): messages.TestStepResult {
     const query = new Query();
     this.envelopes.forEach((envelope) => query.update(envelope));

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -302,6 +302,7 @@ function bindHook(stepBinding: StepBinding): void {
   const bindingOptions: IDefineTestStepHookOptions = {
     timeout: stepBinding.timeout,
     tags: stepBinding.tag === DEFAULT_TAG ? undefined : stepBinding.tag,
+    ...stepBinding.hookOptions ?? {},
   };
 
   logger.trace("Binding hook:", stepBinding);

--- a/cucumber-tsflow/src/hook-decorators.ts
+++ b/cucumber-tsflow/src/hook-decorators.ts
@@ -1,20 +1,20 @@
+import type {IDefineTestCaseHookOptions} from '@cucumber/cucumber/lib/support_code_library_builder/types';
 import { BindingRegistry } from "./binding-registry";
 import { Callsite } from "./our-callsite";
 import { StepBinding, StepBindingFlags } from "./step-binding";
 import { normalizeTag } from "./tag-normalization";
 
-interface HookOptions {
-  tag?: string;
-
-  timeout?: number;
-}
+// Replace `tags` with `tag` for backwards compatibility
+type HookOptions = Omit<IDefineTestCaseHookOptions, 'tags'> & {
+  tag?: string,
+};
 
 function overloadedOption(tag?: string | HookOptions): HookOptions {
   if (tag === undefined || typeof tag === "string") {
     return { tag };
   }
 
-  return tag;
+  return tag
 }
 
 function createHookDecorator(
@@ -23,7 +23,7 @@ function createHookDecorator(
 ): MethodDecorator {
   const callsite = Callsite.capture(2);
 
-  const { tag, timeout } = overloadedOption(tagOrOption);
+  const { tag, timeout, ...hookOptions } = overloadedOption(tagOrOption);
 
   return <T>(
     target: any,
@@ -39,6 +39,7 @@ function createHookDecorator(
       tag: normalizeTag(tag),
       callsite: callsite,
       timeout: timeout,
+      hookOptions: hookOptions,
     };
 
     BindingRegistry.instance.registerStepBinding(stepBinding);

--- a/cucumber-tsflow/src/step-binding.ts
+++ b/cucumber-tsflow/src/step-binding.ts
@@ -1,3 +1,4 @@
+import type {IDefineTestStepHookOptions} from '@cucumber/cucumber/lib/support_code_library_builder/types';
 import { Callsite } from "./our-callsite";
 import { StepBindingFlags } from "./step-binding-flags";
 
@@ -44,6 +45,8 @@ export interface StepBinding {
    * The wrapper Option passing to cucumber
    */
   wrapperOption?: any;
+
+  hookOptions?: Omit<IDefineTestStepHookOptions, 'tags'|'timeout'>;
 
   /**
    * The callsite of the step binding.

--- a/cucumber.js
+++ b/cucumber.js
@@ -14,7 +14,7 @@ module.exports = cucumberPkg.version.startsWith("7.")
     default: {
       requireModule: ["ts-node/register"],
       require: ["cucumber-tsflow-specs/src/**/*.ts"],
-      tags: 'now @oldApis',
+      tags: 'not @oldApis',
       worldParameters: {
         foo: "bar"
       }

--- a/cucumber.js
+++ b/cucumber.js
@@ -6,6 +6,7 @@ module.exports = cucumberPkg.version.startsWith("7.")
       "--publish-quiet",
       "--require-module ts-node/register",
       "--require cucumber-tsflow-specs/src/**/*.ts",
+      "--tags 'not @newApis'",
       "--world-parameters '{\"foo\":\"bar\"}'"
     ].join(" ")
   }

--- a/cucumber.js
+++ b/cucumber.js
@@ -14,6 +14,7 @@ module.exports = cucumberPkg.version.startsWith("7.")
     default: {
       requireModule: ["ts-node/register"],
       require: ["cucumber-tsflow-specs/src/**/*.ts"],
+      tags: 'now @oldApis',
       worldParameters: {
         foo: "bar"
       }


### PR DESCRIPTION
Any extra hook option available on the installed Cucumber version is now re-exported on the hook bindings.

`tags` is renamed to `tag` to maintain backward compatibility. This might be removed on `v5`, unclear.

Added tests for the difference between versions to ensure the values are checked by the type system correctly.

- Closes #129 