### PR TITLE
Add support for Cucumber 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cucumberVersion: ['^7', '^8', '^9']
+        cucumberVersion: ['^7', '^8', '^9', '^10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3

--- a/cucumber-tsflow/package.json
+++ b/cucumber-tsflow/package.json
@@ -32,6 +32,6 @@
     "underscore": "^1.8.3"
   },
   "peerDependencies": {
-    "@cucumber/cucumber": "^7 || ^8 || ^9"
+    "@cucumber/cucumber": "^7 || ^8 || ^9 || ^10"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "@cucumber/cucumber": "^9.1.2",
-        "@types/node": "^16",
+        "@cucumber/cucumber": "^10",
+        "@types/node": "^18",
         "@types/underscore": "1.11.4",
         "jest": "^29.2.2",
         "lerna": "^6.0.1",
@@ -592,18 +592,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
@@ -698,9 +686,9 @@
       "dev": true
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-9.4.0.tgz",
-      "integrity": "sha512-NYui5lwyGJatlrC3xiE861yQwICGIHVZvqLCv+IwG+wfqDpTW4WPrzX9qdgXTqoOfuhmY79MbkgnRPYs2Z1nkw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-10.0.0.tgz",
+      "integrity": "sha512-TPPIftmegCyoIWyitYzHa8ucuFtwiFVvYAolVHc6oLP7hqa79exHiRiADcPtIJiiqe0JallDuYtKhT5tW/wOIA==",
       "dev": true,
       "dependencies": {
         "@cucumber/ci-environment": "9.2.0",
@@ -720,7 +708,7 @@
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
-        "glob": "^7.1.6",
+        "glob": "^10.3.10",
         "has-ansi": "^4.0.1",
         "indent-string": "^4.0.0",
         "is-installed-globally": "^0.4.0",
@@ -732,6 +720,7 @@
         "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
+        "read-pkg-up": "^7.0.1",
         "resolve-pkg": "^2.0.0",
         "semver": "7.5.3",
         "string-argv": "^0.3.1",
@@ -742,13 +731,13 @@
         "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
         "yaml": "^2.2.2",
-        "yup": "^0.32.11"
+        "yup": "1.2.0"
       },
       "bin": {
         "cucumber-js": "bin/cucumber.js"
       },
       "engines": {
-        "node": "14 || 16 || >=18"
+        "node": "18 || >=20"
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
@@ -758,6 +747,120 @@
       "dev": true,
       "dependencies": {
         "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/@cucumber/cucumber/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@cucumber/gherkin": {
@@ -3085,12 +3188,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.197",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
-      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -3104,9 +3201,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-      "integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+      "version": "18.18.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.5.tgz",
+      "integrity": "sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -6504,9 +6601,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.0.tgz",
-      "integrity": "sha512-uKmsITSsF4rUWQHzqaRUuyAir3fZfW3f202Ee34lz/gZCi970CPZwyQXLGNgWJvvZbvFyzeyGq0+4fcG/mBKZg==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8229,12 +8326,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true
-    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -9116,12 +9207,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "node_modules/nanoclone": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
-      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
-      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10583,9 +10668,9 @@
       }
     },
     "node_modules/property-expr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "dev": true
     },
     "node_modules/proto-list": {
@@ -11005,12 +11090,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
       "dev": true
     },
     "node_modules/regexp-match-indices": {
@@ -12003,6 +12082,12 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -12886,21 +12971,27 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
-      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.2.0.tgz",
+      "integrity": "sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/lodash": "^4.14.175",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "nanoclone": "^0.2.1",
-        "property-expr": "^2.0.4",
-        "toposort": "^2.0.2"
-      },
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     ]
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.1.2",
-    "@types/node": "^16",
+    "@cucumber/cucumber": "^10",
+    "@types/node": "^18",
     "@types/underscore": "1.11.4",
     "jest": "^29.2.2",
     "lerna": "^6.0.1",


### PR DESCRIPTION
This PR updates cucumber to the latest major version.

As well as updating cucumber, I've updated `types/node` to avoid using any feature that the package may suggest because one of the breaking changes was dropping support for node 16. I've updated to the same version used for node in CI.

[The upgrade guide](https://github.com/cucumber/cucumber-js/blob/main/UPGRADING.md#1000) says that we should use one of the extensions allowed for the configuration files, and be wary of any dependencies in the use of `require`. Seems like both these cases doesn't require changes, but I would be happy to help if there's any

---

This PR tackle the issue #131 