### PR TITLE
feat(di): support state objects requiring other state objects

### DIFF
--- a/cucumber-tsflow-specs/features/custom-context-objects.feature
+++ b/cucumber-tsflow-specs/features/custom-context-objects.feature
@@ -55,3 +55,227 @@ Feature: Custom context objects
         Then it passes
         And the output contains "The state is 'initial value'"
         And the output contains "The state is 'step value'"
+
+    Scenario: Custom context objects can depend on other custom context objects two levels deep
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario a
+                Given the state is "initial value"
+                When I set the state to "step value"
+                Then the state is "step value"
+            """
+        And a file named "support/level-one-state.ts" with:
+            """ts
+            import {binding} from 'cucumber-tsflow';
+            import {LevelTwoState} from './level-two-state';
+
+            @binding([LevelTwoState])
+            export class LevelOneState {
+                constructor(public levelTwoState: LevelTwoState) {
+                }
+            }
+            """
+        And a file named "support/level-two-state.ts" with:
+            """ts
+            export class LevelTwoState {
+                public value: string = "initial value";
+            }
+            """
+        And a file named "step_definitions/one.ts" with:
+            """ts
+            import {LevelTwoState} from '../support/level-two-state';
+            import {binding, when} from 'cucumber-tsflow';
+
+            @binding([LevelTwoState])
+            class Steps {
+                public constructor(private readonly levelTwoState: LevelTwoState) {
+                }
+
+                @when("I set the state to {string}")
+                public setState(newValue: string) {
+                    this.levelTwoState.value = newValue;
+                }
+            }
+
+            export = Steps;
+            """
+        And a file named "step_definitions/two.ts" with:
+            """ts
+            import {LevelOneState} from '../support/level-one-state';
+            import {binding, then} from 'cucumber-tsflow';
+            import * as assert from 'node:assert';
+
+            @binding([LevelOneState])
+            class Steps {
+                public constructor(private readonly levelOneState: LevelOneState) {}
+
+                @then("the state is {string}")
+                public checkValue(value: string) {
+                    console.log(`The state is '${this.levelOneState.levelTwoState.value}'`);
+                    assert.equal(this.levelOneState.levelTwoState.value, value, "State value does not match");
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output contains "The state is 'initial value'"
+        And the output contains "The state is 'step value'"
+
+    Scenario: Custom context objects can depend on other custom context objects three levels deep
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario a
+                Given the state is "initial value"
+                When I set the state to "step value"
+                Then the state is "step value"
+            """
+        And a file named "support/level-one-state.ts" with:
+            """ts
+            import {binding} from 'cucumber-tsflow';
+            import {LevelTwoState} from './level-two-state';
+
+            @binding([LevelTwoState])
+            export class LevelOneState {
+                constructor(public levelTwoState: LevelTwoState) {
+                }
+            }
+            """
+        And a file named "support/level-two-state.ts" with:
+            """ts
+            import {binding} from 'cucumber-tsflow';
+            import {LevelThreeState} from './level-three-state';
+
+            @binding([LevelThreeState])
+            export class LevelTwoState {
+                constructor(public levelThreeState: LevelThreeState) {
+                }
+            }
+            """
+        And a file named "support/level-three-state.ts" with:
+            """ts
+            export class LevelThreeState {
+                public value: string = "initial value";
+            }
+            """
+        And a file named "step_definitions/one.ts" with:
+            """ts
+            import {LevelThreeState} from '../support/level-three-state';
+            import {binding, when} from 'cucumber-tsflow';
+
+            @binding([LevelThreeState])
+            class Steps {
+                public constructor(private readonly levelThreeState: LevelThreeState) {
+                }
+
+                @when("I set the state to {string}")
+                public setState(newValue: string) {
+                    this.levelThreeState.value = newValue;
+                }
+            }
+
+            export = Steps;
+            """
+        And a file named "step_definitions/two.ts" with:
+            """ts
+            import {LevelOneState} from '../support/level-one-state';
+            import {binding, then} from 'cucumber-tsflow';
+            import * as assert from 'node:assert';
+
+            @binding([LevelOneState])
+            class Steps {
+                public constructor(private readonly levelOneState: LevelOneState) {}
+
+                @then("the state is {string}")
+                public checkValue(value: string) {
+                    console.log(`The state is '${this.levelOneState.levelTwoState.levelThreeState.value}'`);
+                    assert.equal(this.levelOneState.levelTwoState.levelThreeState.value, value, "State value does not match");
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output contains "The state is 'initial value'"
+        And the output contains "The state is 'step value'"
+
+
+    Scenario: Circular dependencies are explicitly communicated to the developer
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: some feature
+              Scenario: scenario a
+                Given the state is "initial value"
+                When I set the state to "step value"
+                Then the state is "step value"
+            """
+        And a file named "support/state-one.ts" with:
+            """ts
+            import {binding} from 'cucumber-tsflow';
+            import {StateTwo} from './state-two';
+
+            @binding([StateTwo])
+            export class StateOne {
+                constructor(public stateTwo: StateTwo) {
+                }
+            }
+            """
+        And a file named "support/state-two.ts" with:
+            """ts
+            import {StateOne} from './state-one';
+            import {binding} from 'cucumber-tsflow';
+
+            @binding([StateOne])
+            export class StateTwo {
+                public value: string = "initial value";
+                constructor(public stateOne: StateOne) {
+                }
+            }
+            """
+        And a file named "step_definitions/one.ts" with:
+            """ts
+            import {StateTwo} from '../support/state-two';
+            import {binding, when} from 'cucumber-tsflow';
+
+            @binding([StateTwo])
+            class Steps {
+                public constructor(private readonly stateTwo: StateTwo) {
+                }
+
+                @when("I set the state to {string}")
+                public setState(newValue: string) {
+                    this.stateTwo.value = newValue;
+                }
+            }
+
+            export = Steps;
+            """
+        And a file named "step_definitions/two.ts" with:
+            """ts
+            import {StateOne} from '../support/state-one';
+            import {binding, then} from 'cucumber-tsflow';
+            import * as assert from 'node:assert';
+
+            @binding([StateOne])
+            class Steps {
+                public constructor(private readonly stateOne: StateOne) {}
+
+                @then("the state is {string}")
+                public checkValue(value: string) {
+                    console.log(`The state is '${this.stateOne.stateTwo.value}'`);
+                    assert.equal(this.stateOne.stateTwo.value, value, "State value does not match");
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it fails
+        And the error output contains text:
+            """
+            Undefined context type at index 0 for StateOne, do you possibly have a circular dependency?
+            """

--- a/cucumber-tsflow/src/binding-decorator.ts
+++ b/cucumber-tsflow/src/binding-decorator.ts
@@ -68,6 +68,14 @@ export function binding(requiredContextTypes?: ContextType[]): TypeDecorator {
       requiredContextTypes
     );
 
+    if (Array.isArray(requiredContextTypes)) {
+      for (const i in requiredContextTypes) {
+        if (typeof requiredContextTypes[i] === 'undefined') {
+          throw new Error(`Undefined context type at index ${i} for ${target.name}, do you possibly have a circular dependency?`);
+        }
+      }
+    }
+
     const allBindings: StepBinding[] = [
       ...bindingRegistry.getStepBindingsForTarget(target),
       ...bindingRegistry.getStepBindingsForTarget(target.prototype),

--- a/cucumber-tsflow/src/types.ts
+++ b/cucumber-tsflow/src/types.ts
@@ -19,7 +19,7 @@ export type TagName = string;
  * Represents a class that will be injected into a binding class to provide context
  * during the execution of a Cucumber scenario.
  */
-export type CustomContextType = new () => any;
+export type CustomContextType = new (...args: any[]) => any;
 
 export type ProvidedContextType =
   | typeof ScenarioInfo
@@ -37,7 +37,7 @@ const providedPrototypes: ProvidedContextType[] = [
 ];
 
 export function isProvidedContextType(
-  typ: ContextType
+  typ: ContextType,
 ): typ is ProvidedContextType {
   return providedPrototypes.some((proto) => Object.is(typ, proto));
 }


### PR DESCRIPTION
G'day 👋

We've just started using this package and it's pretty sweet!

One of the things we've tried to do is to utilise functionality more like dependency injection. What we often want to do is create a "service" which can contain some state or some methods to affect the system under test and modify the state.

As we've added more test cases in, we've wanted to be able to then this "service" have another "service" injected into it etc.

The `@binding()` functionality functions a lot like lightweight dependency injection for our use cases, but falls short that anything that has `@binding()` can't be "injected" to something else with `binding()`

This was primarily enforced before with `CustomContextType` which has been loosened up to allow this use case.

There's additional specs to cover some different ways to use it, including explicitly catching issues that arise from circular dependencies (the constructor prototype is `undefined` in these cases)

Let me know what you think, happy to add any more tests as necessary 😀