### PR TITLE
Use property key name to help identify unique hook bindings

### DIFF
--- a/cucumber-tsflow-specs/features/global-hooks.feature
+++ b/cucumber-tsflow-specs/features/global-hooks.feature
@@ -166,6 +166,43 @@ Feature: Support for Cucumber hooks
             ..
             """
 
+    Scenario: Binding multiple global hooks on the same line
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: Feature
+                Scenario: example one
+                    Given a step
+
+                Scenario: example two
+                    Given a step
+            """
+        And a file named "step_definitions/steps.ts" with:
+            """ts
+            import {binding, given, beforeAll} from 'cucumber-tsflow';
+
+            @binding()
+            class Steps {
+                @beforeAll()public static one() { console.log('one') }@beforeAll()public static two() { console.log('two') }
+
+                @given("a step")
+                public given() {
+                    console.log('step');
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output contains text once:
+            """
+            one
+            two
+            .step
+            ...step
+            ..
+            """
+
     Scenario: Binding multiple afterAll hooks
         Given a file named "features/a.feature" with:
             """feature

--- a/cucumber-tsflow-specs/features/hooks.feature
+++ b/cucumber-tsflow-specs/features/hooks.feature
@@ -155,6 +155,43 @@ Feature: Support for Cucumber hooks
             .hook two has executed
             """
 
+
+    Scenario: Binding multiple hooks same line
+        Given a file named "features/a.feature" with:
+            """feature
+            Feature: Feature
+                Scenario: example
+                    Given a step
+            """
+        And a file named "step_definitions/steps.ts" with:
+            """ts
+            import {binding, given, before} from 'cucumber-tsflow';
+
+            @binding()
+            class Steps {
+                private state = 'no hook executed';
+
+                @before()public hookOne() {console.log(this.state);this.state = 'hook one has executed';}@before()public hookTwo() {console.log(this.state);this.state = 'hook two has executed';}
+
+                @given("a step")
+                public given() {
+                    console.log(this.state);
+                    this.state = 'step has executed';
+                }
+            }
+
+            export = Steps;
+            """
+        When I run cucumber-js
+        Then it passes
+        And the output does not contain "step has not executed"
+        And the output contains text:
+            """
+            .no hook executed
+            .hook one has executed
+            .hook two has executed
+            """
+
     Scenario: Binding multiple after hooks
         Given a file named "features/a.feature" with:
             """feature

--- a/cucumber-tsflow/src/binding-registry.ts
+++ b/cucumber-tsflow/src/binding-registry.ts
@@ -162,7 +162,8 @@ export class BindingRegistry {
       return (
         a.callsite.filename === b.callsite.filename &&
         a.callsite.lineNumber === b.callsite.lineNumber &&
-        String(a.stepPattern) === String(b.stepPattern)
+        String(a.stepPattern) === String(b.stepPattern) &&
+        a.targetPropertyKey === b.targetPropertyKey
       );
     }
   }


### PR DESCRIPTION
I ran into an issue where I was using [tsx](https://www.npmjs.com/package/tsx) to execute cucumber and  tsflow with the following command: 
`NODE_OPTIONS='--import tsx/esm' cucumber-js --import features/support/steps-specflow.ts`

I noticed if I added more then one `@before()` or `@after()` hook to a class then tsflow would only execute the first hook that was defined on the class. When debugging I could see all the stepBindings for my class had `lineNumber: 1` so it seems like tsx was minifying my source code when it transformed the TypeScript to JavaScript.

This pr adds `targetPropertyKey` as an additional discriminator to the `isSameStepBinding` check to help with the scenario where multiple hooks have the same lineNumber as a result of build tooling.