### PR TITLE
Improve support for packages using "type": "module" in their package.json

### DIFF
--- a/bin/create-node-module-types.sh
+++ b/bin/create-node-module-types.sh
@@ -1,0 +1,5 @@
+cat >cucumber-tsflow/dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/cucumber-tsflow/package.json
+++ b/cucumber-tsflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cucumber-tsflow",
   "description": "Provides 'specflow' like bindings for CucumberJS 7.0.0+ in TypeScript 1.7+.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "author": "Tim Roberts <tim@timjroberts.com>",
   "maintainers": [
     {
@@ -11,7 +11,14 @@
     }
   ],
   "license": "MIT",
-  "main": "./dist",
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    }
+  },
+  "types": "./dist/esm/index.d.ts",
   "keywords": [
     "testing",
     "bdd",

--- a/cucumber-tsflow/src/logger.ts
+++ b/cucumber-tsflow/src/logger.ts
@@ -1,5 +1,8 @@
-import * as log4js from "log4js";
+import * as log4jsModule from "log4js";
+// @ts-expect-error
+import log4js from "log4js";
 
-const logger = log4js.getLogger("cucumber-js.tsflow");
+const getLogger = log4js?.getLogger || log4jsModule.getLogger;
+const logger = getLogger("cucumber-js.tsflow");
 
 export default logger;

--- a/cucumber-tsflow/src/our-callsite.ts
+++ b/cucumber-tsflow/src/our-callsite.ts
@@ -1,4 +1,4 @@
-import * as callsites from "callsites";
+import callsites from "callsites";
 // @ts-ignore
 import * as sourceMapSupport from "source-map-support";
 

--- a/cucumber-tsflow/src/provided-context.ts
+++ b/cucumber-tsflow/src/provided-context.ts
@@ -2,7 +2,7 @@
 import {
   ICreateAttachment,
   ICreateLog,
-} from "@cucumber/cucumber/lib/runtime/attachment_manager";
+} from "@cucumber/cucumber/lib/runtime/attachment_manager/index";
 import { Readable } from "stream";
 
 export class WorldParameters<T = any> {

--- a/cucumber-tsflow/tsconfig.esm.json
+++ b/cucumber-tsflow/tsconfig.esm.json
@@ -1,19 +1,18 @@
 {
   "compilerOptions": {
     "composite": true,
-    "module": "umd",
-    "moduleResolution": "node",
+    "module": "es2022",
+    "moduleResolution": "node16",
     "target": "es6",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": false,
     "experimentalDecorators": true,
-    "outDir": "./dist/cjs",
+    "outDir": "./dist/esm",
     "rootDir": "./src"
   },
   "include": ["./src/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf tmp tsconfig.tsbuildinfo cucumber-tsflow/tsconfig.tsbuildinfo cucumber-tsflow/dist cucumber-tsflow-specs/tsconfig.tsbuildinfo",
-    "build": "tsc -p cucumber-tsflow",
+    "build": "npm run build:cjs && npm run build:esm && bin/create-node-module-types.sh",
+    "build:cjs": "tsc -p cucumber-tsflow",
+    "build:esm": "tsc -p cucumber-tsflow/tsconfig.esm.json",
     "build:watch": "tsc --build --watch",
     "preinstall": "cd cucumber-tsflow && npm install && cd ../cucumber-tsflow-specs && npm install",
     "postinstall": "lerna bootstrap && npm run fix-peer-cucumber",


### PR DESCRIPTION
I have a [remix project](https://github.com/bmac/jester/blob/main/package.json#L11) where I'm using `cucumber-tsflow` and the root of my project has `"type": "module"` in it's package.json. Unfortunately this changes how [node resolves](https://nodejs.org/api/packages.html#determining-module-system) modules in a way that makes it which makes it somewhat cumbersome to work with `cucumber-tsflow`'s exports. As a result I end up doing this:

```ts
import TsFlow from "cucumber-tsflow";
const { binding, then, when, after, afterAll, before } = TsFlow;
```

Annoyingly, the usually fix for this issue is for the library to accept some additional complexity and ship multiple implementations one in the commonjs format and one in the esm format. So that is what the PR attempts to do.


The current implementation of this pr would require a major version bump because `"type": "module"` users such as myself would no longer see a default export and would need to change their code to use named exports.
```ts
// This errors
import TsFlow from "cucumber-tsflow";

// This works
import { binding, then, when, after, afterAll, before } from "cucumber-tsflow";
```

I don't believe there is any impact for user without `"type": "module"`. Additionally if you would prefer to avoid a major version bump we can create a default export for the `"type": "module"`  users that matches the current behavior.